### PR TITLE
switch writeFile to writeFileSync to remove race

### DIFF
--- a/lib/scripts/functions/build-development-css.js
+++ b/lib/scripts/functions/build-development-css.js
@@ -42,7 +42,7 @@ async function buildDevCSS(env) {
     fontFaceCSS + compiledHydrogenCoreCSS + compiledHydrogenUtilityCSS;
   // Write the file.
   fs.mkdirSync(path + config.folders.styles + '/hydrogen/cleaned');
-  fs.writeFile(
+  fs.writeFileSync(
     path + config.folders.styles + '/hydrogen/cleaned/hydrogen.css',
     devHydrogen,
     function (err) {

--- a/lib/scripts/functions/clean-css.js
+++ b/lib/scripts/functions/clean-css.js
@@ -290,7 +290,7 @@ async function createCleanCSS(env) {
       });
     }
     fs.mkdirSync(path + config.folders.styles + '/hydrogen/cleaned');
-    fs.writeFile(
+    fs.writeFileSync(
       path + config.folders.styles + '/hydrogen/cleaned/hydrogen.css',
       hydrogen,
       function (err) {


### PR DESCRIPTION
In some situations, like running in a Docker container, it seems like the writeFile command occasionally does not finish writing out the intermediate file before the next step begins.  This causes the hydrogen.css file in the cleaned directory to be 0 bytes when the compress step begins and reports an unhandled error.

Changing to writeFileSync removes the race condition and forces the file write to complete before the next step starts.