### PR TITLE
Removed unused glob packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -112,14 +112,6 @@
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
       "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
     },
-    "ansi-yellow": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-yellow/-/ansi-yellow-0.1.1.tgz",
-      "integrity": "sha1-y5NW8vRscy8OMZnmEClVp32oPB0=",
-      "requires": {
-        "ansi-wrap": "0.1.0"
-      }
-    },
     "any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -235,11 +227,6 @@
           "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
         }
       }
-    },
-    "array-union": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-3.0.1.tgz",
-      "integrity": "sha512-1OvF9IbWwaeiM9VhzYXVQacMibxpXOMYVNIvMtKRyX9SImBXpKcFr8XvFDeEslCyuH/t6KRt7HEO94AlP8Iatw=="
     },
     "array-unique": {
       "version": "0.3.2",
@@ -459,11 +446,6 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
-    },
-    "bluebird": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-      "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE="
     },
     "boolbase": {
       "version": "1.0.0",
@@ -1280,11 +1262,6 @@
         "domhandler": "^4.2.0"
       }
     },
-    "dotdir-regex": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dotdir-regex/-/dotdir-regex-0.1.0.tgz",
-      "integrity": "sha1-1F30yIY75vVZPXFpFDgXZ+k4wLY="
-    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -1348,11 +1325,6 @@
       "requires": {
         "once": "^1.4.0"
       }
-    },
-    "ends-with": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ends-with/-/ends-with-0.2.0.tgz",
-      "integrity": "sha1-L52pjVelDP2kVxzkM5AAUA9Oa4o="
     },
     "engine.io": {
       "version": "3.5.0",
@@ -1530,78 +1502,12 @@
         }
       }
     },
-    "expand-range": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "requires": {
-        "fill-range": "^2.1.0"
-      },
-      "dependencies": {
-        "fill-range": {
-          "version": "2.2.4",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
-          "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^3.0.0",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        }
-      }
-    },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
       "requires": {
         "homedir-polyfill": "^1.0.1"
-      }
-    },
-    "export-files": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/export-files/-/export-files-2.1.1.tgz",
-      "integrity": "sha1-u/ZFdAU6CeTrmOX0NQHVcrLDzn8=",
-      "requires": {
-        "lazy-cache": "^1.0.3"
-      },
-      "dependencies": {
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
-        }
       }
     },
     "ext": {
@@ -1748,11 +1654,6 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "optional": true
-    },
-    "filename-regex": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -1965,11 +1866,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
-    },
     "fs-extra": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
@@ -2036,453 +1932,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-base": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-      "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "requires": {
-        "glob-parent": "^2.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
-    "glob-fs": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/glob-fs/-/glob-fs-0.1.7.tgz",
-      "integrity": "sha512-f0U3u9xK8MEYtKDCnZXvZrZAy4uNp+KSA4xfaKI/NxbE6HXhqUBQ485Uwd6jQa/Q6z1yKi804WT9y53RrwuMxQ==",
-      "requires": {
-        "async": "^1.3.0",
-        "bluebird": "^2.9.33",
-        "component-emitter": "^1.2.0",
-        "ends-with": "^0.2.0",
-        "export-files": "^2.0.1",
-        "extend-shallow": "^2.0.0",
-        "get-value": "^1.1.5",
-        "glob-fs-dotfiles": "^0.1.6",
-        "glob-fs-gitignore": "^0.1.5",
-        "glob-parent": "^1.2.0",
-        "graceful-fs": "^4.1.2",
-        "is-dotdir": "^0.1.0",
-        "is-dotfile": "^1.0.1",
-        "is-glob": "^2.0.0",
-        "is-windows": "^0.1.0",
-        "kind-of": "^2.0.0",
-        "lazy-cache": "^0.1.0",
-        "micromatch": "github:jonschlinkert/micromatch#2.2.0",
-        "mixin-object": "^2.0.0",
-        "object-visit": "^0.1.0",
-        "object.omit": "^1.1.0",
-        "parse-filepath": "^0.6.1",
-        "relative": "^3.0.1",
-        "set-value": "^0.2.0",
-        "starts-with": "^1.0.2",
-        "through2": "^2.0.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.1.0.tgz",
-          "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "array-slice": "^0.2.3"
-          }
-        },
-        "array-slice": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
-          "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU="
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "get-value": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/get-value/-/get-value-1.3.1.tgz",
-          "integrity": "sha1-isfvTyA4I5KyZGVI+bmtLcbIlkI=",
-          "requires": {
-            "arr-flatten": "^1.0.1",
-            "is-extendable": "^0.1.1",
-            "lazy-cache": "^0.2.4",
-            "noncharacters": "^1.1.0"
-          },
-          "dependencies": {
-            "lazy-cache": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-            }
-          }
-        },
-        "glob-parent": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.3.0.tgz",
-          "integrity": "sha1-lx7dgW7V21hwW1gHlkemTQrveWg=",
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "is-absolute": {
-          "version": "0.2.6",
-          "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-          "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
-          "requires": {
-            "is-relative": "^0.2.1",
-            "is-windows": "^0.2.0"
-          },
-          "dependencies": {
-            "is-windows": {
-              "version": "0.2.0",
-              "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-              "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
-            }
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-relative": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-          "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
-          "requires": {
-            "is-unc-path": "^0.1.1"
-          }
-        },
-        "is-unc-path": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-          "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
-          "requires": {
-            "unc-path-regex": "^0.1.0"
-          }
-        },
-        "is-windows": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.1.1.tgz",
-          "integrity": "sha1-vjEHFUMc+rzMVKs5USEPoLbQGr4="
-        },
-        "isobject": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o="
-        },
-        "kind-of": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-          "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-          "requires": {
-            "is-buffer": "^1.0.2"
-          }
-        },
-        "micromatch": {
-          "version": "github:jonschlinkert/micromatch#5017fd78202e04c684cc31d3c2fb1f469ea222ff",
-          "from": "github:jonschlinkert/micromatch#2.2.0",
-          "requires": {
-            "arr-diff": "^1.0.1",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.0",
-            "expand-brackets": "^0.1.1",
-            "extglob": "^0.3.0",
-            "filename-regex": "^2.0.0",
-            "is-glob": "^1.1.3",
-            "kind-of": "^1.1.0",
-            "object.omit": "^1.1.0",
-            "parse-glob": "^3.0.1",
-            "regex-cache": "^0.4.2"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "1.1.3",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
-              "integrity": "sha1-tMZLgwPTkRRJKkYNNkzPsNPAoEU="
-            },
-            "kind-of": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz",
-              "integrity": "sha1-FAo9LUGjbS78+pN3tiwk+ElaXEQ="
-            }
-          }
-        },
-        "object-visit": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-0.1.0.tgz",
-          "integrity": "sha1-sbtnSfIo7nbgxC84UdKKFNIzziY=",
-          "requires": {
-            "isobject": "^1.0.0"
-          }
-        },
-        "parse-filepath": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-0.6.3.tgz",
-          "integrity": "sha1-OOF6c+Xk5ndrrpUG/DzLFLw6K4A=",
-          "requires": {
-            "is-absolute": "^0.2.2",
-            "map-cache": "^0.2.0"
-          }
-        },
-        "set-value": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.2.0.tgz",
-          "integrity": "sha1-c7CmglwVjGoWqCu9yVd1vyqCX6s=",
-          "requires": {
-            "isobject": "^1.0.0",
-            "noncharacters": "^1.1.0"
-          }
-        }
-      }
-    },
-    "glob-fs-dotfiles": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/glob-fs-dotfiles/-/glob-fs-dotfiles-0.1.6.tgz",
-      "integrity": "sha1-tPF7c8GIQYq6R80gbPWnImtKiUk="
-    },
-    "glob-fs-gitignore": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/glob-fs-gitignore/-/glob-fs-gitignore-0.1.6.tgz",
-      "integrity": "sha1-iF5vQS+FnMWXVhVIKdvVVybN6ZI=",
-      "requires": {
-        "findup-sync": "^1.0.0",
-        "micromatch": "^2.3.11",
-        "parse-gitignore": "^0.2.0"
-      },
-      "dependencies": {
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
-        },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
-        "detect-file": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-0.1.0.tgz",
-          "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
-          "requires": {
-            "fs-exists-sync": "^0.1.0"
-          }
-        },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "expand-tilde": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-1.2.2.tgz",
-          "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
-          "requires": {
-            "os-homedir": "^1.0.1"
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "findup-sync": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-1.0.0.tgz",
-          "integrity": "sha1-b35LV7buOkA3tEFOrt6j9Y9x4Ow=",
-          "requires": {
-            "detect-file": "^0.1.0",
-            "is-glob": "^2.0.1",
-            "micromatch": "^2.3.7",
-            "resolve-dir": "^0.1.0"
-          }
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "requires": {
-            "for-in": "^1.0.1"
-          }
-        },
-        "global-modules": {
-          "version": "0.2.3",
-          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-0.2.3.tgz",
-          "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
-          "requires": {
-            "global-prefix": "^0.1.4",
-            "is-windows": "^0.2.0"
-          }
-        },
-        "global-prefix": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-0.1.5.tgz",
-          "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
-          "requires": {
-            "homedir-polyfill": "^1.0.0",
-            "ini": "^1.3.4",
-            "is-windows": "^0.2.0",
-            "which": "^1.2.12"
-          }
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-windows": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw="
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-          "requires": {
-            "for-own": "^0.1.4",
-            "is-extendable": "^0.1.1"
-          }
-        },
-        "resolve-dir": {
-          "version": "0.1.1",
-          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-0.1.1.tgz",
-          "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
-          "requires": {
-            "expand-tilde": "^1.2.2",
-            "global-modules": "^0.2.3"
-          }
-        }
       }
     },
     "glob-parent": {
@@ -2750,26 +2199,6 @@
         "ini": "^1.3.4",
         "is-windows": "^1.0.1",
         "which": "^1.2.14"
-      }
-    },
-    "globby": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-12.0.2.tgz",
-      "integrity": "sha512-lAsmb/5Lww4r7MM9nCCliDZVIKbZTavrsunAsHLr9oHthrZP1qi7/gAnHOsUs9bLvEt2vKVJhHmxuL7QbDuPdQ==",
-      "requires": {
-        "array-union": "^3.0.1",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.7",
-        "ignore": "^5.1.8",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "dependencies": {
-        "slash": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew=="
-        }
       }
     },
     "glogg": {
@@ -3379,27 +2808,6 @@
         }
       }
     },
-    "is-dotdir": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-dotdir/-/is-dotdir-0.1.0.tgz",
-      "integrity": "sha1-2h5UZPWfw6g8HYIrWs4JG0X+azE=",
-      "requires": {
-        "dotdir-regex": "^0.1.0"
-      }
-    },
-    "is-dotfile": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
-    },
-    "is-equal-shallow": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-      "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "requires": {
-        "is-primitive": "^2.0.0"
-      }
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -3458,16 +2866,6 @@
       "requires": {
         "isobject": "^3.0.1"
       }
-    },
-    "is-posix-bracket": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
-    },
-    "is-primitive": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
     },
     "is-relative": {
       "version": "1.0.0",
@@ -3564,14 +2962,6 @@
       "requires": {
         "default-resolution": "^2.0.0",
         "es6-weak-map": "^2.0.1"
-      }
-    },
-    "lazy-cache": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.1.0.tgz",
-      "integrity": "sha1-1s1FAlHUFbcBA3ZfYxMKAEmgN5U=",
-      "requires": {
-        "ansi-yellow": "^0.1.1"
       }
     },
     "lazystream": {
@@ -3866,11 +3256,6 @@
         }
       }
     },
-    "math-random": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
-    },
     "mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
@@ -3945,22 +3330,6 @@
         }
       }
     },
-    "mixin-object": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-      "requires": {
-        "for-in": "^0.1.3",
-        "is-extendable": "^0.1.1"
-      },
-      "dependencies": {
-        "for-in": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
-        }
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4019,11 +3388,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
       "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
-    },
-    "noncharacters": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/noncharacters/-/noncharacters-1.1.0.tgz",
-      "integrity": "sha1-rzPfMP1Q7TxTzSAiWPJa2pC1QNI="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -4154,30 +3518,6 @@
         "make-iterator": "^1.0.0"
       }
     },
-    "object.omit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-1.1.0.tgz",
-      "integrity": "sha1-nRfqFneOUFfeundSxvVfFJaCnpQ=",
-      "requires": {
-        "for-own": "^0.1.3",
-        "isobject": "^1.0.0"
-      },
-      "dependencies": {
-        "for-own": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "requires": {
-            "for-in": "^1.0.1"
-          }
-        },
-        "isobject": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
-          "integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o="
-        }
-      }
-    },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -4232,11 +3572,6 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
-    },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
@@ -4282,57 +3617,6 @@
         "is-absolute": "^1.0.0",
         "map-cache": "^0.2.0",
         "path-root": "^0.1.1"
-      }
-    },
-    "parse-gitignore": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/parse-gitignore/-/parse-gitignore-0.2.0.tgz",
-      "integrity": "sha1-mHBtCfD5PuhjSLch/+4GBrwJPXQ=",
-      "requires": {
-        "ends-with": "^0.2.0",
-        "is-glob": "^2.0.0",
-        "starts-with": "^1.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
-      }
-    },
-    "parse-glob": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-      "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "requires": {
-        "glob-base": "^0.3.0",
-        "is-dotfile": "^1.0.0",
-        "is-extglob": "^1.0.0",
-        "is-glob": "^2.0.0"
-      },
-      "dependencies": {
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        }
       }
     },
     "parse-node-version": {
@@ -4729,11 +4013,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
       "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ=="
     },
-    "preserve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
-    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -4811,23 +4090,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
-    },
-    "randomatic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
-      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
-      "requires": {
-        "is-number": "^4.0.0",
-        "kind-of": "^6.0.0",
-        "math-random": "^1.0.1"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
-        }
-      }
     },
     "range-parser": {
       "version": "1.2.1",
@@ -4940,14 +4202,6 @@
         "resolve": "^1.1.6"
       }
     },
-    "regex-cache": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "requires": {
-        "is-equal-shallow": "^0.1.3"
-      }
-    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -4955,29 +4209,6 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
-      }
-    },
-    "relative": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
-      "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
-      "requires": {
-        "isobject": "^2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        }
       }
     },
     "remove-bom-buffer": {
@@ -5609,11 +4840,6 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
-    "starts-with": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/starts-with/-/starts-with-1.0.2.tgz",
-      "integrity": "sha1-Fnk6cp2J1M89T7LtovkIrjV/GW8="
     },
     "static-extend": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,6 @@
     "cssnano-preset-lite": "^2.0.1",
     "del": "^6.0.0",
     "glob": "^7.2.0",
-    "glob-fs": "^0.1.7",
-    "globby": "^12.0.2",
     "gulp": "^4.0.2",
     "gulp-concat": "^2.6.1",
     "gulp-footer": "^2.1.0",


### PR DESCRIPTION
Hiya! The repo is just using `glob`, not these other ones :)

I noticed because I was trying to build gc-digital-talent on a minimal build machine, and glob-fs is unmaintained and has a dependency on a `git://` uri instead of the npm package repository, which led to some complications. Removing the dep on glob-fs would resolve that the minor issue